### PR TITLE
Add ebs mapping to delete on termination and use SSD

### DIFF
--- a/packer.json
+++ b/packer.json
@@ -14,7 +14,19 @@
     "instance_type": "m3.medium",
     "ssh_username": "ubuntu",
     "ami_name": "FISMA Ready Baseline Ubuntu ({{timestamp}} - Packer)",
-    "ami_description": "A FISMA-ready baseline Ubuntu image."
+    "ami_description": "A FISMA-ready baseline Ubuntu image.",
+    "ami_block_device_mappings" : [{
+      "device_name": "/dev/sda1",
+      "volume_type" : "gp2",
+      "volume_size": 30,
+      "delete_on_termination": true
+    },
+    {
+      "device_name": "/dev/sdk",
+      "volume_size": 40,
+      "volume_type" : "gp2",
+      "delete_on_termination": true
+    }]
   }],
   "provisioners": [{
 	    "type": "chef-solo",


### PR DESCRIPTION
It create 2 block mappings in accordance with version 0.1.4:
- 30gb `sda1` (root) with SSD type
- 40gb `sdk` with SSD type
