### PR TITLE
ignore .env for autoenv users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 *.lock
 berks-cookbooks
+/.env

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .DS_Store
 *.lock
 berks-cookbooks
-/.env
+.env


### PR DESCRIPTION
I use [`autoenv`](https://github.com/kennethreitz/autoenv), which makes use of an `.env` file to turn on environment variables upon entering a directory. It'd be real bad for someone to accidentally commit that! This ignores it.