### PR TITLE
Update hardening guide

### DIFF
--- a/hardening.md
+++ b/hardening.md
@@ -36,17 +36,19 @@ With vagrant and installed we can start preparing our environment.
 
 Before we can bring a virtual machine online we need one more thing, a [provider](https://docs.vagrantup.com/v2/providers/) for Vagrant to work with. This guide covers both [virtualbox](http://docs.vagrantup.com/v2/virtualbox) for running locally and [aws](https://github.com/mitchellh/vagrant-aws) to launch your machine on Amazon EC2.
 
-	apt-get update
-	apt-get upgrade
-	Y
+#### Virtualbox Provider:
 
-Grab a snack, this will take a bit.
+Homebrew comes in handy once again with a little help from the homebrew extension [cask](http://caskroom.io/).
 
-## Partitions management
+First, we'll add then cask extension.
 
-References:
+    brew install caskroom/cask/brew-cask
+    
+Then we'll use cask to set up virtualbox.
 
-- [General info on partitions](http://www.howtoforge.com/linux_lvm)
+    brew cask install virtualbox
+    
+Users of other operating systems can find downloads and instructions on for the installation of vagrant and virtualbox at [vagrantup](https://www.vagrantup.com/downloads.html) and [virtualbox](https://www.virtualbox.org/wiki/Downloads) respectively.
 
 - [Partitioning with fdisk](http://www.liquidweb.com/kb/disk-partitioning-with-fdisk-2/)
 

--- a/hardening.md
+++ b/hardening.md
@@ -168,11 +168,38 @@ Pay special attention when partitioning. Depending on your provider `/dev/xvda` 
 
 Users of the AWS provider might notice one or more additional devices at `/dev/xvdb`. This is your [instance store](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html) which is beyond the scope of this doc and can be safely ignored.
 
-	   Device Boot      Start         End      Blocks   Id  System
-	/dev/sdb1            2048    10487807     5242880   83  Linux
-	/dev/sdb2        10487808    20973567     5242880   83  Linux
-	/dev/sdb3        20973568    31459327     5242880   83  Linux
-	/dev/sdb4        31459328    41945087     5242880   83  Linux
+### Partitioning:
+
+You can now can add partitions to the second disk. Check to see if it's there.
+
+	sudo sgdisk -p /dev/sdb
+
+In this listing, you should now see:
+
+	Disk /dev/xvdk: 83886080 sectors, 40.0 GiB
+	...
+	Total free space is 83886013 sectors (40.0 GiB)
+
+	Number  Start (sector)    End (sector)  Size       Code  Name
+
+Since we have 40GB to work with we'll make each partition 10GB. Pay special attention to the final partition, we're not specifying a set size, rather it will use all remaining space on the disk.
+
+	sudo sgdisk -n 1:0:+10G /dev/sdb
+	sudo sgdisk -n 2:0:+10G /dev/sdb
+	sudo sgdisk -n 3:0:+10G /dev/sdb
+	sudo sgdisk -n 4:0:+ /dev/sdb
+
+Lets have a look at our newly created partitions.
+
+	Disk /dev/sdb: 83886080 sectors, 40.0 GiB
+	...
+	Total free space is 2014 sectors (1007.0 KiB)
+	
+	Number  Start (sector)    End (sector)  Size       Code  Name
+	   1            2048        20973567   10.0 GiB    8300  
+	   2        20973568        41945087   10.0 GiB    8300  
+	   3        41945088        62916607   10.0 GiB    8300  
+	   4        62916608        83886046   10.0 GiB    8300  
 
 Looks great! But all that's happened is that you've created device listing within the OS. Ubuntu still doesn't think these are physical volumes ready for use.
 

--- a/hardening.md
+++ b/hardening.md
@@ -10,7 +10,7 @@ There might be additional controls necessary for your system at the OS level, ab
 
 We strongly encourage the community to help us improve this baseline given an ever-changing risk environment. We believe there is rarely any security in obscurity and that there will always be a greater level of expertise on the outside of team than inside. By doing this work in the open, we will more quickly and effectively identify flaws or potential improvements.
 
-## Before you start
+## Before You Start
 
 We've edited this guide to address both the Vagrant and Amazon Web Services (AWS) use cases. As we improve the baseline, we will likely separate the guide based on the deployment environment. For the time being, differences between Vagrant and AWS are noted in-line.
 
@@ -18,7 +18,7 @@ The guide is currently written presuming intermediate familiarity with Linux, th
 
 These are controls to implement in a production environment. They may not be currently appropriate for a development environment that is in constant change. Some potential workarounds are discussed at the end of the guide. [TBD]
 
-## Vagrant and Virtualbox sitting in a tree
+## Getting Started
 
 If you are doing this work via Vagrant, before you do your first _vagrant up_, you might have a version mistmatch between the Guest Additions installed on the box vs your install of VirtualBox. Let's fix that. Go to the same folder as the Vagrantfile you're about to use.
 

--- a/hardening.md
+++ b/hardening.md
@@ -74,17 +74,21 @@ Add a second disk and finish configuring your box for use with the virtualbox pr
 
 This reconfigures the [vagrant box](https://docs.vagrantup.com/v2/boxes.html) we just [initialized](https://docs.vagrantup.com/v2/cli/init.html) to feature a second, 40GB disk which we'll start carving up in just a moment. Don't worry, this new disk won't actually take up 40GB of space. It will only consume as much space as the data data we place on it through the course of this exercise which isn't much.
 
-### Disk devices for AWS
+#### AWS Provider:
 
-In the AWS device namespace, it becomes problematic if you occupy the sdb - sde device namespace. Within your instance, you may see these mapped to xvdb - xvde respectively. If you select sdf - sdl when creating your instance, these problems can be avoided. The rest of the partition guidance in this section is written from the perspective of Vagrant. If you're in AWS, when creating an additional EBS device, select sdf - sdl when launching an additional EBS device with your EC2 instance, and then anticipate seeing xvdf - xvdl in the below commands instead of sdb.
+Add the aws provider plugin to Vagrant.
 
-### Partition the disk devices
+	vagrant plugin install vagrant-aws
+	
+Add the blank 'dummy' box which we'll use as a base for launching into AWS.
 
-You can now can add partitions to sdb. Check to see if it's there.
+	vagrant box add dummy https://github.com/mitchellh/vagrant-aws/raw/master/dummy.box
 
-	fdisk -l
+Export your AWS credentials as environment variables.
 
-In this listing, you should now see:
+	export AWS_ACCESS_KEY=YOURAWSACCESSKEY
+	export AWS_SECRET_KEY=YOURAWSSECRETKEY
+
 
 	Disk /dev/sdb
 

--- a/hardening.md
+++ b/hardening.md
@@ -156,17 +156,17 @@ Before we do anything, let's make sure we're all patched up.
 
 Grab a snack, this will take a bit.
 
-You should now see _/dev/sdb1_ listed!
+## Partitions Management:
 
-Rinse and repeat until you have _sdb1_ -> _sdb4_ in the dialog listed by the _p_ command. *Warning:* you have to write this config to disk! Hit _w_.
+References:
 
-	Command (m for help): w
+- [General info on partitions](http://www.howtoforge.com/linux_lvm)
 
-This will also exit _fdisk_. Let's take a last look to confirm our work:
+- [Partitioning with (s)gdisk](http://www.rodsbooks.com/gdisk/sgdisk-walkthrough.html)
 
-	fdisk -l
+Pay special attention when partitioning. Depending on your provider `/dev/xvda` or `/dev/sda` is the home of your system disk. Re-partitioning these devices will most assuredly break your box!
 
-	(...)
+Users of the AWS provider might notice one or more additional devices at `/dev/xvdb`. This is your [instance store](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html) which is beyond the scope of this doc and can be safely ignored.
 
 	   Device Boot      Start         End      Blocks   Id  System
 	/dev/sdb1            2048    10487807     5242880   83  Linux

--- a/hardening.md
+++ b/hardening.md
@@ -1,6 +1,6 @@
 # Hardening Ubuntu 14.04 to 18F standards
 
-This hardening guide, and the operating system (OS) configuration it produces, is in *early beta* and will change. The baseline is currently version 0.1.2. 18F is currently testing this baseline for deployment into production.
+This hardening guide, and the operating system (OS) configuration it produces, is in *early beta* and will change. The baseline is currently version 0.1.4. 18F is currently testing this baseline for deployment into production.
 
 There are many recommended controls that are already in place with given a fresh install of either Ubuntu 12.04 LTS or Ubuntu 14.04 LTS. These controls are fully itemized at TBD and are covered by our an open source compliance testing suite we are currently working on.
 

--- a/hardening.md
+++ b/hardening.md
@@ -130,15 +130,18 @@ If all goes well you'll find yourself at the prompt of a fresh Ubuntu 14.04.1 LT
 
 	vagrant@vagrant-ubuntu-trusty-64:~$
 
+### Preparing the Disk:
 
-Hit _m_ for a list of commands. We'll go with _n_ to start making a new partition. If you can live with 4 partitions of this disk, primary partitions are the way to go.
+Since we created and attached a second disk as part of the Vagrantfile above, there's very little to do here. Just confirm the disk is present.
 
-	Command (m for help): n
-	Partition type:
-	   p   primary (0 primary, 0 extended, 4 free)
-	   e   extended
-	Select (default p): p
-	Partition number (1-4, default 1): 1
+	sgdisk -p /dev/sdb
+	Creating new GPT entries.
+	...	
+	Total free space is 83886013 sectors (40.0 GiB)
+	
+	Number  Start (sector)    End (sector)  Size       Code  Name
+	vagrant@vagrant-ubuntu-trusty-64:~$ 
+
 
 On what cylinder will the partition start? Rarely a good idea to set something non-default. Just hit enter to move on.
 

--- a/hardening.md
+++ b/hardening.md
@@ -93,6 +93,24 @@ Export your AWS credentials as environment variables.
 	 
 Add a second disk and finish configuring your box for use with the virtualbox provider by replacing the contents of the newly created [Vagrantfile](https://docs.vagrantup.com/v2/vagrantfile/)  with the following.
 
+**./Vagrantfile**
+
+	Vagrant.configure("2") do |config|
+	  config.vm.box = "dummy"
+	
+	  config.vm.provider :aws do |aws, override|
+	    aws.keypair_name = "your-keypair-name"
+	    aws.ami = "ami-9eaa1cf6"
+	    override.ssh.username = "ubuntu"
+	    override.ssh.private_key_path = "/path/to/your-keypair-name.pem"
+	    aws.tags = {
+	      'Name' => 'fisma-ready/ubuntu-lts'
+	    }
+	    aws.block_device_mapping = [{ 'DeviceName' => '/dev/xvdk', 'Ebs.VolumeSize' => 40 }]
+	    aws.security_groups = ['your-security-group-which-allows-ssh']
+	  end
+	end
+
 There are several placeholder parameters that will need updating.
 
 - *your-keypair-name* - The name of the [AWS keypair](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html) to use with the instance.

--- a/hardening.md
+++ b/hardening.md
@@ -50,15 +50,15 @@ Then we'll use cask to set up virtualbox.
     
 Users of other operating systems can find downloads and instructions on for the installation of vagrant and virtualbox at [vagrantup](https://www.vagrantup.com/downloads.html) and [virtualbox](https://www.virtualbox.org/wiki/Downloads) respectively.
 
-- [Partitioning with fdisk](http://www.liquidweb.com/kb/disk-partitioning-with-fdisk-2/)
+##### Additional Configuration - VirtualBox:
 
-When you create your fresh new Ubuntu box via Vagrant or AWS, you only have "sda" (or "xvda") - a physical volume for booting the OS. In Vagrant, there may be a volume dedicated for itself. Don't touch those or your may break your box.
+Add a second disk and finish configuring your box for use with the virtualbox provider by replacing the contents of the newly created [Vagrantfile](https://docs.vagrantup.com/v2/vagrantfile/)  with the following:
 
-### Disk devices for Vagrant
+**./Vagrantfile**
 
 You first need to create a physical disk which will be labeled "sdb" - see the *b*? This is the second physical disk with "sda" being the first one.
 
-In order to create sdb, you need to add it through your VM manager. If you use VirtualBox, [here's a walkthrough.](https://www.youtube.com/watch?v=vsljCzZ70bE)
+This reconfigures the [vagrant box](https://docs.vagrantup.com/v2/boxes.html) we just [initialized](https://docs.vagrantup.com/v2/cli/init.html) to feature a second, 40GB disk which we'll start carving up in just a moment. Don't worry, this new disk won't actually take up 40GB of space. It will only consume as much space as the data data we place on it through the course of this exercise which isn't much.
 
 ### Disk devices for AWS
 

--- a/hardening.md
+++ b/hardening.md
@@ -20,7 +20,7 @@ These are controls to implement in a production environment. They may not be cur
 
 ## Getting Started
 
-If you are doing this work via Vagrant, before you do your first _vagrant up_, you might have a version mistmatch between the Guest Additions installed on the box vs your install of VirtualBox. Let's fix that. Go to the same folder as the Vagrantfile you're about to use.
+First and foremost we'll need a VM to work with.  To do this, we'll start by getting Vagrant installed then use it to abstract away all the complications of spinning up a new VM.
 
 	vagrant plugin install vagrant-vbguest
 	vagrant up

--- a/hardening.md
+++ b/hardening.md
@@ -56,7 +56,21 @@ Add a second disk and finish configuring your box for use with the virtualbox pr
 
 **./Vagrantfile**
 
-You first need to create a physical disk which will be labeled "sdb" - see the *b*? This is the second physical disk with "sda" being the first one.
+	Vagrant.configure(2) do |config|
+      config.vm.box = "ubuntu/trusty64"
+      config.vm.provider "virtualbox" do | vm |
+        file_to_disk = './disks/xvdk.vdi'
+        vm.customize ['createhd', 
+                      '--filename', file_to_disk, 
+                      '--size', 40 * 1024]
+        vm.customize ['storageattach', :id, 
+                      '--storagectl', 'SATAController', 
+                      '--port', 1, 
+                      '--device', 0, 
+                      '--type', 'hdd', 
+                      '--medium', file_to_disk]
+      end
+    end
 
 This reconfigures the [vagrant box](https://docs.vagrantup.com/v2/boxes.html) we just [initialized](https://docs.vagrantup.com/v2/cli/init.html) to feature a second, 40GB disk which we'll start carving up in just a moment. Don't worry, this new disk won't actually take up 40GB of space. It will only consume as much space as the data data we place on it through the course of this exercise which isn't much.
 

--- a/hardening.md
+++ b/hardening.md
@@ -22,18 +22,19 @@ These are controls to implement in a production environment. They may not be cur
 
 First and foremost we'll need a VM to work with.  To do this, we'll start by getting Vagrant installed then use it to abstract away all the complications of spinning up a new VM.
 
-	vagrant plugin install vagrant-vbguest
-	vagrant up
+### Vagrant:
 
-During the upgrade, you'll get a note that the XFree86 Window system failed to install. You won't need it.
+[Vagrant](https://www.vagrantup.com/) is a quick, easy way to configure and launch consistent virtual environments across a variety of platforms for test and development. As usual homebrew makes using Vagrant simple for Mac OSX users. 
 
-## Spin up your AMI
+	brew install vagrant
 
-If you are doing this work via AWS, start with an Ubuntu 14.04 AMI that uses paravirtualization. Tests have not yet been completed using hardware-assisted virtualization (HVM) based AMIs, but we do not at this point anticipate any issues. Interested in testing? Assign an issue to yourself.
+With vagrant and installed we can start preparing our environment.
 
-## Get up to date
+	mkdir fisma-ready-ubuntu
+	cd fisma-ready-ubuntu
+	vagrant init ubuntu/trusty64
 
-Before we do anything, let's make sure we're all patched up.
+Before we can bring a virtual machine online we need one more thing, a [provider](https://docs.vagrantup.com/v2/providers/) for Vagrant to work with. This guide covers both [virtualbox](http://docs.vagrantup.com/v2/virtualbox) for running locally and [aws](https://github.com/mitchellh/vagrant-aws) to launch your machine on Amazon EC2.
 
 	apt-get update
 	apt-get upgrade

--- a/hardening.md
+++ b/hardening.md
@@ -148,13 +148,13 @@ In the AWS device namespace, it becomes problematic if you occupy the sdb - sde 
 
 The rest of the partition guidance in this section is written from the perspective of the virtualbox provider using device `/dev/sdb`.  If you're running in AWS simply substitute `/dev/xvdk` for `/dev/sdb`.
 
-Determining the last sector also determines how big the partition is. We have 30GB to play with, let's make each 6GB.
+## Getting Up To Date:
 
-	Last sector, +sectors or +size{K,M,G} (2048-52428799, default 52428799): +5G
+Before we do anything, let's make sure we're all patched up.
 
-Hit _p_ to see what happened.
+	sudo apt-get update && sudo apt-get upgrade -y
 
-	Command (m for help): p
+Grab a snack, this will take a bit.
 
 You should now see _/dev/sdb1_ listed!
 

--- a/hardening.md
+++ b/hardening.md
@@ -142,11 +142,11 @@ Since we created and attached a second disk as part of the Vagrantfile above, th
 	Number  Start (sector)    End (sector)  Size       Code  Name
 	vagrant@vagrant-ubuntu-trusty-64:~$ 
 
+#### Device Names:
 
-On what cylinder will the partition start? Rarely a good idea to set something non-default. Just hit enter to move on.
+In the AWS device namespace, it becomes problematic if you occupy the sdb - sde device names. Within your instance, you may see these mapped to xvdb - xvde respectively. In the AWS Provider Vagrantfile above we've mapped our second disk to /dev/xvdk to avoid any potential conflicts. 
 
-	First sector (2048-52428799, default 2048):
-	Last sector, +sectors or +size{K,M,G} (2048-52428799, default 52428799):
+The rest of the partition guidance in this section is written from the perspective of the virtualbox provider using device `/dev/sdb`.  If you're running in AWS simply substitute `/dev/xvdk` for `/dev/sdb`.
 
 Determining the last sector also determines how big the partition is. We have 30GB to play with, let's make each 6GB.
 

--- a/hardening.md
+++ b/hardening.md
@@ -89,8 +89,18 @@ Export your AWS credentials as environment variables.
 	export AWS_ACCESS_KEY=YOURAWSACCESSKEY
 	export AWS_SECRET_KEY=YOURAWSSECRETKEY
 
+##### Additional Configuration - AWS:
+	 
+Add a second disk and finish configuring your box for use with the virtualbox provider by replacing the contents of the newly created [Vagrantfile](https://docs.vagrantup.com/v2/vagrantfile/)  with the following.
 
-	Disk /dev/sdb
+There are several placeholder parameters that will need updating.
+
+- *your-keypair-name* - The name of the [AWS keypair](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html) to use with the instance.
+
+- */path/to/your-keypair-name.pem* - The path and filename of your [AWS private key](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html).
+
+- *your-security-group-which-allows-ssh* - The name of an EC2 [security group which allows SSH](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-network-security.html#security-group-rules).
+
 
 Jump into fdisk to start your partitioning!
 

--- a/hardening.md
+++ b/hardening.md
@@ -119,10 +119,17 @@ There are several placeholder parameters that will need updating.
 
 - *your-security-group-which-allows-ssh* - The name of an EC2 [security group which allows SSH](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-network-security.html#security-group-rules).
 
+#### Starting Up:
 
-Jump into fdisk to start your partitioning!
+Lets go ahead and start our machine with [vagrant up](https://docs.vagrantup.com/v2/cli/up.html) and connect to it via SSH with [vagrant ssh](https://docs.vagrantup.com/v2/cli/ssh.html).
 
-	fdisk /dev/sdb
+	vagrant up
+	vagrant ssh
+	
+If all goes well you'll find yourself at the prompt of a fresh Ubuntu 14.04.1 LTS (Trusty) VM.
+
+	vagrant@vagrant-ubuntu-trusty-64:~$
+
 
 Hit _m_ for a list of commands. We'll go with _n_ to start making a new partition. If you can live with 4 partitions of this disk, primary partitions are the way to go.
 

--- a/hardening.md
+++ b/hardening.md
@@ -4,17 +4,17 @@ This hardening guide, and the operating system (OS) configuration it produces, i
 
 There are many recommended controls that are already in place with given a fresh install of either Ubuntu 12.04 LTS or Ubuntu 14.04 LTS. These controls are fully itemized at TBD and are covered by our an open source compliance testing suite we are currently working on.
 
-Controls were implemented on both an Ubuntu 12.04 box downloaded from the [VagrantCloud](https://vagrantcloud.com/hashicorp/precise64/version/2/provider/virtualbox.box) and the default 640-bit Ubuntu 14.04 Amazon Machine Image (AMI).
+Controls were implemented on both an Ubuntu 12.04 box downloaded from the [VagrantCloud](https://vagrantcloud.com/hashicorp/precise64/version/2/provider/virtualbox.box) and the default 64-bit Ubuntu 14.04 Amazon Machine Image (AMI).
 
 There might be additional controls necessary for your system at the OS level, above and beyond the following. Please consult with your cybersecurity and DevOps teams.
 
-We strongly encourage the community to help us improve this baseline given an ever-changing risk environment. We believe there is rarely any security in obscurity and that there will always be a greater level of expertise on the outside of team than inside. By doing this work in the open, we will more quickly and effectively identifiy flaws or potential improvements.
+We strongly encourage the community to help us improve this baseline given an ever-changing risk environment. We believe there is rarely any security in obscurity and that there will always be a greater level of expertise on the outside of team than inside. By doing this work in the open, we will more quickly and effectively identify flaws or potential improvements.
 
 ## Before you start
 
-We've edited this guide to address both the Vagrant and Amazon Web Services (AWS) use cases. As we improve the baseline, we will likely seperate the guide based on the deployment environment. For the time being, differences between Vagrant and AWS are noted in-line.
+We've edited this guide to address both the Vagrant and Amazon Web Services (AWS) use cases. As we improve the baseline, we will likely separate the guide based on the deployment environment. For the time being, differences between Vagrant and AWS are noted in-line.
 
-The guide is currently written presuming intermediate familarity with Linux, the command line, Vagrant/AWS, and system administration in general. References are provided were applicable to provide additional background.
+The guide is currently written presuming intermediate familiarity with Linux, the command line, Vagrant/AWS, and system administration in general. References are provided where applicable to provide additional background.
 
 These are controls to implement in a production environment. They may not be currently appropriate for a development environment that is in constant change. Some potential workarounds are discussed at the end of the guide. [TBD]
 


### PR DESCRIPTION
Updates the hardening guide to...

- Provide Vagrantfiles for launching in VirtualBox or AWS easily via Vagrant with a secondary disk.
- Unify the instructions post-Vagrantfile.
- Use sgdisk for a simplified, non-interactive partitioning experience.
- Make use of homebrew and cask.
- Fix assorted typos.

Still lacks changes to get away from 'physical' partitioning and backup / copy could be more efficient. Now that the guide and script are in sync, updates of that sort should be easier.