### PR TITLE
ensure authorized_keys is cleaned when baking

### DIFF
--- a/packer.json
+++ b/packer.json
@@ -57,7 +57,13 @@
       ],
       "json": {
         "grub_passwd": "hello"
-      }
+       }
+      },
+      {
+      "inline": [
+        "truncate -s0 /home/ubuntu/.ssh/authorized_keys"
+      ],
+      "type": "shell"
     }
   ]
 }


### PR DESCRIPTION
Just an inline shell command to ensure authorized_keys is clean when provisioning completes.