### PR TITLE
Update metadata.rb

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'Installs/Configures packer'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.0'
 
-%w{ apt }.each do |cookbook|
+%w{ apt git }.each do |cookbook|
   depends cookbook
 end
 


### PR DESCRIPTION
Prioring to adding the 'git' dependancy, I received the following error when running ami.sh:

root@BLOCKED:/home/ubuntu/ubuntu-lts# ./ami.sh 
Resolving cookbook dependencies...
Fetching 'packer' from source at .
Fetching cookbook index from https://supermarket.getchef.com...
Installing apt (2.7.0) from https://supermarket.getchef.com ([opscode] https://supermarket.chef.io/api/v1)
Installing build-essential (2.2.3) from https://supermarket.getchef.com ([opscode] https://supermarket.chef.io/api/v1)
Installing chef_handler (1.1.6) from https://supermarket.getchef.com ([opscode] https://supermarket.chef.io/api/v1)
Installing dmg (2.2.2) from https://supermarket.getchef.com ([opscode] https://supermarket.chef.io/api/v1)
Installing git (4.2.2) from https://supermarket.getchef.com ([opscode] https://supermarket.chef.io/api/v1)
Using packer (0.1.0) from source at .
Installing windows (1.36.6) from https://supermarket.getchef.com ([opscode] https://supermarket.chef.io/api/v1)
Installing yum (3.6.0) from https://supermarket.getchef.com ([opscode] https://supermarket.chef.io/api/v1)
Installing yum-epel (0.6.0) from https://supermarket.getchef.com ([opscode] https://supermarket.chef.io/api/v1)
Vendoring apt (2.7.0) to ../vendor/cookbooks/apt
Vendoring build-essential (2.2.3) to ../vendor/cookbooks/build-essential
Vendoring chef_handler (1.1.6) to ../vendor/cookbooks/chef_handler
Vendoring dmg (2.2.2) to ../vendor/cookbooks/dmg
Vendoring git (4.2.2) to ../vendor/cookbooks/git
Vendoring packer (0.1.0) to ../vendor/cookbooks/packer
Vendoring windows (1.36.6) to ../vendor/cookbooks/windows
Vendoring yum (3.6.0) to ../vendor/cookbooks/yum
Vendoring yum-epel (0.6.0) to ../vendor/cookbooks/yum-epel
amazon-ebs output will be in this color.

==> amazon-ebs: Inspecting the source AMI...
==> amazon-ebs: Creating temporary keypair: packer 5543e4fc-4395-1d99-d967-78891916beb2
==> amazon-ebs: Creating temporary security group for this instance...
==> amazon-ebs: Authorizing SSH access on the temporary security group...
==> amazon-ebs: Launching a source AWS instance...
    amazon-ebs: Instance ID: i-e393adcc
==> amazon-ebs: Waiting for instance (i-e393adcc) to become ready...
==> amazon-ebs: Waiting for SSH to become available...
==> amazon-ebs: Connected to SSH!
==> amazon-ebs: Provisioning with chef-solo
    amazon-ebs: Installing Chef...
    amazon-ebs: % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
    amazon-ebs: Dload  Upload   Total   Spent    Left  Speed
    amazon-ebs: 100 18990  100 18990    0     0   115k      0 --:--:-- --:--:-- --:--:--  115k
    amazon-ebs: Downloading Chef  for ubuntu...
    amazon-ebs: downloading https://www.opscode.com/chef/metadata?v=&prerelease=false&nightlies=false&p=ubuntu&pv=14.04&m=x86_64
    amazon-ebs: to file /tmp/install.sh.1386/metadata.txt
    amazon-ebs: trying wget...
    amazon-ebs: url	https://opscode-omnibus-packages.s3.amazonaws.com/ubuntu/10.04/x86_64/chef_12.3.0-1_amd64.deb
    amazon-ebs: md5	d8421c9b3010deb03e713ada00387e8a
    amazon-ebs: sha256	e06eb748e44d0a323f4334aececdf3c2c74d2f97323678ad3a43c33ac32b4f81
    amazon-ebs: downloaded metadata file looks valid...
    amazon-ebs: downloading https://opscode-omnibus-packages.s3.amazonaws.com/ubuntu/10.04/x86_64/chef_12.3.0-1_amd64.deb
    amazon-ebs: to file /tmp/install.sh.1386/chef_12.3.0-1_amd64.deb
    amazon-ebs: trying wget...
    amazon-ebs: Comparing checksum with sha256sum...
    amazon-ebs:
    amazon-ebs: WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
    amazon-ebs:
    amazon-ebs: You are installing an omnibus package without a version pin.  If you are installing
    amazon-ebs: on production servers via an automated process this is DANGEROUS and you will
    amazon-ebs: be upgraded without warning on new releases, even to new major release.
    amazon-ebs: Letting the version float is only appropriate in desktop, test, development or
    amazon-ebs: CI/CD environments.
    amazon-ebs:
    amazon-ebs: WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
    amazon-ebs:
    amazon-ebs: Installing Chef
    amazon-ebs: installing with dpkg...
    amazon-ebs: Selecting previously unselected package chef.
    amazon-ebs: (Reading database ... 51091 files and directories currently installed.)
    amazon-ebs: Preparing to unpack .../chef_12.3.0-1_amd64.deb ...
    amazon-ebs: Unpacking chef (12.3.0-1) ...
    amazon-ebs: Setting up chef (12.3.0-1) ...
    amazon-ebs: Thank you for installing Chef!
    amazon-ebs: Creating directory: /tmp/packer-chef-solo
    amazon-ebs: Creating directory: /tmp/packer-chef-solo/cookbooks-0
    amazon-ebs: Creating configuration file 'solo.rb'
    amazon-ebs: Creating JSON attribute file
    amazon-ebs: Executing Chef: sudo chef-solo --no-color -c /tmp/packer-chef-solo/solo.rb -j /tmp/packer-chef-solo/node.json
    amazon-ebs: Starting Chef Client, version 12.3.0
    amazon-ebs: Compiling Cookbooks...
    amazon-ebs: [2015-05-01T20:42:49+00:00] WARN: MissingCookbookDependency:
    amazon-ebs: Recipe `git` is not in the run_list, and cookbook 'git'
    amazon-ebs: is not a dependency of any cookbook in the run_list.  To load this recipe,
    amazon-ebs: first add a dependency on cookbook 'git' in the cookbook you're
    amazon-ebs: including it from in that cookbook's metadata.
    amazon-ebs:
    amazon-ebs:
    amazon-ebs: ================================================================================
    amazon-ebs: Recipe Compile Error in /tmp/packer-chef-solo/cookbooks-0/packer/recipes/default.rb
    amazon-ebs: ================================================================================
    amazon-ebs:
    amazon-ebs: NoMethodError
    amazon-ebs: -------------
    amazon-ebs: No resource or method named `git_client' for `Chef::Recipe "default"'
    amazon-ebs:
    amazon-ebs: Cookbook Trace:
    amazon-ebs: ---------------
    amazon-ebs: /tmp/packer-chef-solo/cookbooks-0/git/recipes/default.rb:19:in `from_file'
    amazon-ebs: /tmp/packer-chef-solo/cookbooks-0/packer/recipes/default.rb:6:in `from_file'
    amazon-ebs:
    amazon-ebs: Relevant File Content:
    amazon-ebs: ----------------------
    amazon-ebs: /tmp/packer-chef-solo/cookbooks-0/git/recipes/default.rb:
    amazon-ebs:
    amazon-ebs: 12:  #
    amazon-ebs: 13:  # Unless required by applicable law or agreed to in writing, software
    amazon-ebs: 14:  # distributed under the License is distributed on an "AS IS" BASIS,
    amazon-ebs: 15:  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    amazon-ebs: 16:  # See the License for the specific language governing permissions and
    amazon-ebs: 17:  # limitations under the License.
    amazon-ebs: 18:
    amazon-ebs: 19>> git_client 'default' do
    amazon-ebs: 20:    action :install
    amazon-ebs: 21:  end
    amazon-ebs: 22:
    amazon-ebs:
    amazon-ebs:
    amazon-ebs: Running handlers:
    amazon-ebs: [2015-05-01T20:42:49+00:00] ERROR: Running exception handlers
    amazon-ebs: Running handlers complete
    amazon-ebs: [2015-05-01T20:42:49+00:00] ERROR: Exception handlers complete
    amazon-ebs: [2015-05-01T20:42:49+00:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
    amazon-ebs: Chef Client failed. 0 resources updated in 1.436479796 seconds
    amazon-ebs: [2015-05-01T20:42:49+00:00] ERROR: No resource or method named `git_client' for `Chef::Recipe "default"'
    amazon-ebs: [2015-05-01T20:42:49+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
==> amazon-ebs: Terminating the source AWS instance...
==> amazon-ebs: Deleting temporary security group...
==> amazon-ebs: Deleting temporary keypair...
Build 'amazon-ebs' errored: Error executing Chef: Non-zero exit status: 1

==> Some builds didn't complete successfully and had errors:
--> amazon-ebs: Error executing Chef: Non-zero exit status: 1

==> Builds finished but no artifacts were created.