### PR TITLE
Set chef tmp path to a location that persists post execution of partition.sh

### DIFF
--- a/packer.json
+++ b/packer.json
@@ -62,7 +62,8 @@
     },
     {
       "inline": [
-        "truncate -s0 /home/ubuntu/.ssh/authorized_keys"
+        "truncate -s0 /home/ubuntu/.ssh/authorized_keys",
+        "sudo rm -rf /chef"
       ],
       "type": "shell"
     }

--- a/packer.json
+++ b/packer.json
@@ -57,9 +57,10 @@
       ],
       "json": {
         "grub_passwd": "hello"
-       }
       },
-      {
+      "staging_directory": "/chef"
+    },
+    {
       "inline": [
         "truncate -s0 /home/ubuntu/.ssh/authorized_keys"
       ],


### PR DESCRIPTION
**Why**
By default chef was using the `/tmp` directory which gets deleted when the `partition.sh` script is executed causing the run to fail.

**How**
Set the staging directory to a location that is not affected by the partitioning script. This also adds a command to the inline shell provisioner so that it removes the remnants from the chef run.
