### PR TITLE
homebrew/binary was deprecated, removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Prepared and maintained by **[18F](https://18f.gsa.gov)**, a Federal digital ser
 
 ```bash
 $ brew doctor
-$ brew tap homebrew/binary
 $ brew install packer
 ```
 At press time, we used Packer 0.7.5


### PR DESCRIPTION
homebrew/binary was deprecated. This tap is now empty as all its formulae were migrated